### PR TITLE
Add custom_domain flag to override auth0.com suffixing of domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ config :auth0_ex,
 
 - The v2 `search_engine` API is being deprecated by Auth0.  User queries now specify `search_engine=v3` by default.  If for some reason you need the `v2` engine you can set `v2_search: true` in your config block.
 - if you use pre-created management token, it will always be used for your requests_
-- `AUTH0_DOMAIN` should be entire tenant domain Auth0 provides. We fall back to adding `auth0.com` right now but that will be
-removed in future version. This allows us to use `Auth0Ex` in all tenant regions unlike the previous versions.
+- `AUTH0_DOMAIN` should be entire tenant domain Auth0 provides. We fall back to adding `auth0.com` right now but that will be removed in future version. This allows us to use `Auth0Ex` in all tenant regions unlike the previous versions.
+- If you don't want `auth0.com` to be added, you can set `config :auth0_ex, custom_domain: true`
 
 Export appropriate environment variable and you should be all set.
 

--- a/lib/auth0_ex/utils.ex
+++ b/lib/auth0_ex/utils.ex
@@ -8,7 +8,7 @@ defmodule Auth0Ex.Utils do
     auth0_domain = domain()
 
     base_domain =
-      if String.ends_with?(auth0_domain, "auth0.com") do
+      if String.ends_with?(auth0_domain, "auth0.com") or custom_domain() do
         auth0_domain
       else
         IO.warn(
@@ -26,6 +26,12 @@ defmodule Auth0Ex.Utils do
   def base_url(_), do: base_url()
   def oauth_url, do: "#{base_url()}oauth/token"
   def domain, do: get_config(:domain)
+
+  def custom_domain do
+    :auth0_ex
+    |> Application.get_env(:custom_domain, false)
+    |> Kernel.in([true, "true"])
+  end
 
   def mgmt_token do
     case get_config(:mgmt_token) do


### PR DESCRIPTION
We run a custom Auth0 domain, which is being overridden by the current logic, because
it does not end in `.auth0.com` (it is still a fully qualified tenant URL).

Added the option of setting `config :auth0_ex, custom_domain: true` to disable the
addition of `.auth0.com`.