### PR TITLE
Use import Config instead of use Mix.Config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,4 +1,4 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 import_config "#{Mix.env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :auth0_ex,
   domain: System.get_env("AUTH0_DOMAIN"),

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :auth0_ex,
   domain: System.get_env("AUTH0_DOMAIN"),


### PR DESCRIPTION
This was deprecated a long time ago and will be removed soon.

> warning: use Mix.Config is deprecated. Use the Config module instead