### PR TITLE
Fix supervisor deprecation warning

### DIFF
--- a/lib/auth0_ex/application.ex
+++ b/lib/auth0_ex/application.ex
@@ -11,9 +11,9 @@ defmodule Auth0Ex.Application do
     # Define workers and child supervisors to be supervised
     children = [
       # Starts a worker by calling: Auth0Ex.Worker.start_link(arg1, arg2, arg3)
-      # worker(Auth0Ex.Worker, [arg1, arg2, arg3]),
+      # {Auth0Ex.Worker, [arg1, arg2, arg3]},
 
-      worker(Auth0Ex.TokenState, [])
+      {Auth0Ex.TokenState, []}
     ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html

--- a/lib/auth0_ex/token_state.ex
+++ b/lib/auth0_ex/token_state.ex
@@ -4,8 +4,10 @@ defmodule Auth0Ex.TokenState do
   and potentially other stuff in future for management API
   """
 
+  use Agent
+
   @doc false
-  def start_link do
+  def start_link(_initial_value) do
     Agent.start_link(fn -> %{} end, name: __MODULE__)
   end
 


### PR DESCRIPTION
Fixes the following warning

> warning: Supervisor.Spec.worker/2 is deprecated. Use the new child specifications outlined in the Supervisor module instead
>  lib/auth0_ex/application.ex:16: Auth0Ex.Application.start/2