### PR TITLE
Lift configuration fetching and handling into separate module

### DIFF
--- a/lib/auth0_ex/config.ex
+++ b/lib/auth0_ex/config.ex
@@ -1,0 +1,47 @@
+defmodule Auth0Ex.Config do
+  @moduledoc """
+  All of the configurations pertaining to `Auth0Ex`.
+  """
+
+  @spec domain() :: String.t()
+  def domain do
+    auth0_domain = Application.get_env(:auth0_ex, :domain)
+
+    if String.ends_with?(auth0_domain, "auth0.com") or custom_domain?() do
+      auth0_domain
+    else
+      raise ArgumentError,
+            "the domain specified must be a fully qualified domain name, it should be : <your_tenant>[.optional_region].auth0.com, not just <your_tenant>"
+    end
+  end
+
+  @spec mgmt_client_id() :: String.t() | nil
+  def mgmt_client_id do
+    Application.get_env(:auth0_ex, :mgmt_client_id)
+  end
+
+  @spec mgmt_client_secret() :: String.t() | nil
+  def mgmt_client_secret do
+    Application.get_env(:auth0_ex, :mgmt_client_secret)
+  end
+
+  @spec mgmt_token() :: String.t() | nil
+  def mgmt_token do
+    Application.get_env(:auth0_ex, :mgmt_token)
+  end
+
+  @spec http_opts() :: list()
+  def http_opts do
+    Application.get_env(:auth0_ex, :http_opts) || []
+  end
+
+  @spec user_agent() :: String.t()
+  def user_agent do
+    Application.get_env(:auth0_ex, :user_agent) ||
+      "Auth0Ex <https://github.com/techgaun/auth0_ex>"
+  end
+
+  defp custom_domain? do
+    Application.get_env(:auth0_ex, :custom_domain, false) in [true, "true"]
+  end
+end

--- a/lib/auth0_ex/utils.ex
+++ b/lib/auth0_ex/utils.ex
@@ -3,39 +3,19 @@ defmodule Auth0Ex.Utils do
   Collection module of various utils needed for Auth0Ex
   """
   alias Auth0Ex.Authentication.Token
+  alias Auth0Ex.Config
   alias Auth0Ex.TokenState
 
   def base_url do
-    auth0_domain = domain()
-
-    base_domain =
-      if String.ends_with?(auth0_domain, "auth0.com") or custom_domain() do
-        auth0_domain
-      else
-        IO.warn(
-          "setting domain without full base domain is deprecated and will be removed in future versions\n" <>
-            "domain config should be : <your_tenant>[.optional_region].auth0.com, not just <your_tenant>"
-        )
-
-        "#{auth0_domain}.auth0.com"
-      end
-
-    "https://#{base_domain}/"
+    "https://#{Config.domain()}/"
   end
 
   def base_url(:mgmt), do: "#{base_url()}api/v2/"
   def base_url(_), do: base_url()
   def oauth_url, do: "#{base_url()}oauth/token"
-  def domain, do: get_config(:domain)
-
-  def custom_domain do
-    :auth0_ex
-    |> Application.get_env(:custom_domain, false)
-    |> Kernel.in([true, "true"])
-  end
 
   def mgmt_token do
-    case get_config(:mgmt_token) do
+    case Config.mgmt_token() do
       token when is_binary(token) ->
         token
 
@@ -44,14 +24,12 @@ defmodule Auth0Ex.Utils do
     end
   end
 
-  def http_opts, do: get_config(:http_opts) || []
-  def ua, do: get_config(:user_agent) || "Auth0Ex <https://github.com/techgaun/auth0_ex>"
+  def http_opts, do: Config.http_opts()
+  def ua, do: Config.user_agent()
 
   def req_header, do: [{"User-Agent", ua()}, {"Content-Type", "application/json"}]
   def req_header(:mgmt), do: [{"Authorization", "Bearer #{mgmt_token()}"}] ++ req_header()
   def req_header(_), do: req_header()
-
-  defp get_config(key), do: Application.get_env(:auth0_ex, key)
 
   defp get_token_from_client do
     case TokenState.get(:mgmt_token) do
@@ -70,8 +48,8 @@ defmodule Auth0Ex.Utils do
   end
 
   defp fetch_mgmt_token do
-    client_id = get_config(:mgmt_client_id)
-    client_secret = get_config(:mgmt_client_secret)
+    client_id = Config.mgmt_client_id()
+    client_secret = Config.mgmt_client_secret()
 
     {:ok, %{"access_token" => token}} =
       Token.client_credentials(client_id, client_secret, base_url(:mgmt))

--- a/test/lib/auth0_ex/config_test.exs
+++ b/test/lib/auth0_ex/config_test.exs
@@ -1,0 +1,131 @@
+defmodule Auth0Ex.ConfigTest do
+  use ExUnit.Case
+
+  alias Auth0Ex.Config
+
+  describe "domain/0" do
+    setup do
+      original = Application.get_env(:auth0_ex, :domain)
+
+      on_exit(fn ->
+        Application.put_env(:auth0_ex, :domain, original)
+        Application.put_env(:auth0_ex, :custom_domain, false)
+      end)
+
+      :ok
+    end
+
+    test "domain is returned" do
+      assert "brighterlink.auth0.com" = Config.domain()
+    end
+
+    test "custom domain is specified" do
+      Application.put_env(:auth0_ex, :custom_domain, true)
+      Application.put_env(:auth0_ex, :domain, "auth.example.com")
+
+      assert "auth.example.com" == Config.domain()
+    end
+
+    test "deprecated domain is specified" do
+      Application.put_env(:auth0_ex, :domain, "invalid")
+
+      assert_raise(
+        ArgumentError,
+        ~r/the domain specified must be a fully qualified domain name/,
+        fn ->
+          Config.domain()
+        end
+      )
+    end
+  end
+
+  describe "mgmt_client_id/0" do
+    setup do
+      original = Application.get_env(:auth0_ex, :mgmt_client_id)
+      on_exit(fn -> Application.put_env(:auth0_ex, :mgmt_client_id, original) end)
+      :ok
+    end
+
+    test "returns the set value" do
+      Application.put_env(:auth0_ex, :mgmt_client_id, "foo")
+      assert "foo" == Config.mgmt_client_id()
+    end
+
+    test "returns nil if not set" do
+      Application.delete_env(:auth0_ex, :mgmt_client_id)
+      assert nil == Config.mgmt_client_id()
+    end
+  end
+
+  describe "mgmt_client_secret/0" do
+    setup do
+      original = Application.get_env(:auth0_ex, :mgmt_client_secret)
+      on_exit(fn -> Application.put_env(:auth0_ex, :mgmt_client_secret, original) end)
+      :ok
+    end
+
+    test "returns the set value" do
+      Application.put_env(:auth0_ex, :mgmt_client_secret, "foo")
+      assert "foo" == Config.mgmt_client_secret()
+    end
+
+    test "returns nil if not set" do
+      Application.delete_env(:auth0_ex, :mgmt_client_secret)
+      assert nil == Config.mgmt_client_secret()
+    end
+  end
+
+  describe "mgmt_token/0" do
+    setup do
+      original = Application.get_env(:auth0_ex, :mgmt_token)
+      on_exit(fn -> Application.put_env(:auth0_ex, :mgmt_token, original) end)
+      :ok
+    end
+
+    test "returns the set value" do
+      Application.put_env(:auth0_ex, :mgmt_token, "foo")
+      assert "foo" == Config.mgmt_token()
+    end
+
+    test "returns nil if not set" do
+      Application.delete_env(:auth0_ex, :mgmt_token)
+      assert nil == Config.mgmt_token()
+    end
+  end
+
+  describe "http_opts/0" do
+    setup do
+      original = Application.get_env(:auth0_ex, :http_opts)
+      on_exit(fn -> Application.put_env(:auth0_ex, :http_opts, original) end)
+      :ok
+    end
+
+    test "returns the set value" do
+      Application.put_env(:auth0_ex, :http_opts, foo: :bar)
+      assert [foo: :bar] == Config.http_opts()
+    end
+
+    test "returns an empty list if not set" do
+      Application.delete_env(:auth0_ex, :http_opts)
+      assert [] == Config.http_opts()
+    end
+  end
+
+  describe "user_agent/0" do
+    setup do
+      original = Application.get_env(:auth0_ex, :user_agent)
+      on_exit(fn -> Application.put_env(:auth0_ex, :user_agent, original) end)
+      :ok
+    end
+
+    test "returns the set value" do
+      Application.put_env(:auth0_ex, :user_agent, "MyCustomAgent <http://example.com>")
+      assert "MyCustomAgent <http://example.com>" == Config.user_agent()
+    end
+
+    test "returns an empty list if not set" do
+      Application.delete_env(:auth0_ex, :user_agent)
+      assert "Auth0Ex <https://github.com/techgaun/auth0_ex>" == Config.user_agent()
+    end
+  end
+end


### PR DESCRIPTION
While adding some tests and doing some refactorings, this was one change I could lift out easily that could be considered for upstream.

One breaking change is to now raise an `ArgumentError` for a misconfigured domain. This library has had the deprecation warning for quite some time now and I think it is wise to go ahead and fail. Downstream users should be able to rectify quickly.