### PR TITLE
Fix json decoding

### DIFF
--- a/lib/auth0_ex/parser.ex
+++ b/lib/auth0_ex/parser.ex
@@ -13,9 +13,9 @@ defmodule Auth0Ex.Parser do
   @spec parse(tuple) :: response
   def parse(response) do
     case response do
-      {:ok, %HTTPoison.Response{body: body, headers: headers, status_code: status}}
+      {:ok, %HTTPoison.Response{body: body, headers: _, status_code: status}}
       when status in [200, 201] ->
-        parse_json_or_html(headers, body)
+        maybe_decode(body)
 
       {:ok, %HTTPoison.Response{body: _, headers: _, status_code: 204}} ->
         :ok
@@ -31,16 +31,10 @@ defmodule Auth0Ex.Parser do
     end
   end
 
-  defp parse_json_or_html(headers, body) do
-    case is_json_content_type?(headers) do
-      true -> {:ok, Jason.decode!(body)}
-      false -> {:ok, body}
+  defp maybe_decode(body) do
+    case Jason.decode(body) do
+      {:ok, parsed} -> {:ok, parsed}
+      _ -> {:ok, body}
     end
   end
-
-  defp is_json_content_type?(headers),
-    do:
-      headers
-      |> Map.new()
-      |> Map.get("Content-Type") == "application/json"
 end

--- a/lib/auth0_ex/utils.ex
+++ b/lib/auth0_ex/utils.ex
@@ -27,8 +27,8 @@ defmodule Auth0Ex.Utils do
   def http_opts, do: Config.http_opts()
   def ua, do: Config.user_agent()
 
-  def req_header, do: [{"User-Agent", ua()}, {"Content-Type", "application/json"}]
-  def req_header(:mgmt), do: [{"Authorization", "Bearer #{mgmt_token()}"}] ++ req_header()
+  def req_header, do: [{"user-agent", ua()}, {"content-type", "application/json"}]
+  def req_header(:mgmt), do: [{"authorization", "Bearer #{mgmt_token()}"}] ++ req_header()
   def req_header(_), do: req_header()
 
   defp get_token_from_client do


### PR DESCRIPTION
We have been running into issues where the decoding was broken.

The issue was that you are trying to fetch `Content-Type` from the headers when it was being returned as `content-type`. Rather than trying to figure out the content type to be parsed. We should just try to decode it as json, and then if it fails, just return the body.